### PR TITLE
 path.resolve -> require.resolve

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -2,10 +2,10 @@
 const path = require('path')
 const fs = require('fs')
 
-const SCRIPT_API_PATH = './node_modules/runjs/lib/script.js'
+const SCRIPT_API_PATH = 'runjs/lib/script.js'
 
 try {
-  fs.accessSync(path.resolve(SCRIPT_API_PATH))
+  fs.accessSync(require.resolve(SCRIPT_API_PATH))
 } catch (error) {
   console.error(
     'RunJS not found. Do "npm install runjs --save-dev" or "yarn add --dev runjs" first.'
@@ -13,7 +13,7 @@ try {
   process.exit(1)
 }
 
-const script = require(path.resolve(SCRIPT_API_PATH))
+const script = require(require.resolve(SCRIPT_API_PATH))
 
 if (!script.main) {
   console.error(

--- a/bin/run.js
+++ b/bin/run.js
@@ -2,7 +2,7 @@
 const path = require('path')
 const fs = require('fs')
 
-const SCRIPT_API_PATH = 'runjs/lib/script.js'
+const SCRIPT_API_PATH = '../lib/script.js'
 
 try {
   fs.accessSync(require.resolve(SCRIPT_API_PATH))


### PR DESCRIPTION
this small change restores functionality when runjs installed in a Lerna monorepo (or any repo where the node_modules folder isn't in the standard location)