### PR TITLE
Change default execution shell to bash and enable globstar

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,11 +498,26 @@ const { run } = require('runjs')
 {
     cwd: ..., // current working directory (String)
     async: ... // run command asynchronously (true/false), false by default
+    shell: ... // shell to use, 'bash' by default
     stdio: ... // 'inherit' (default), 'pipe' or 'ignore'
-    env: ... // environment key-value pairs (Object)
+    env: ... // environment key-value pairs (Object), defaults to process.env
     timeout: ...
 }
 ```
+
+**Environment Note**
+
+We default to setting the `BASHOPTS` environment variable to `globstar`, which
+supports the `**` globbing pattern, as many Node.js glob libaries do. Here are
+docs for the globstar option:
+
+> If globstar set, the pattern ‘\*\*’ used in a filename expansion context will match all
+> files and zero or more directories and subdirectories. If the pattern is
+> followed by a ‘/’, only directories and subdirectories match.
+
+To provide consistent results in different environments, you must explicitly
+BASHOPTS through the options object if you want to change the default. Setting
+it in the environment will have no effect.
 
 *Examples:*
 

--- a/test/unit/index.spec.js
+++ b/test/unit/index.spec.js
@@ -76,6 +76,16 @@ describe('api', () => {
           expect(logger.title).toHaveBeenCalledWith('cli-command')
         })
       })
+
+      describe('with shell=bash (default)', () => {
+        it('should execute basic bash commands', () => {
+          // shopt is part of bash, but not 'sh'
+          api.run('shopt -s globstar', { shell: 'bash' }, logger)
+          expect(execSync.mock.calls[0][0]).toEqual('shopt -s globstar')
+          expect(execSync.mock.calls[0][1]).toHaveProperty('shell', 'bash')
+          expect(logger.title).toHaveBeenCalledWith('shopt -s globstar')
+        })
+      })
     })
 
     describe('async version', () => {


### PR DESCRIPTION
This could be a breaking change, although in practice it is unlikely to
break much.

 - "shell" now defaults to bash instead of 'sh', but can changed.
 - "BASHOPTS" defaults to "globstar" for compatibility with many Node.js globbing libraries.

runjs leans heavily on running shell commands, so having a robust shell
execution environment is helpful. In particular, globbling enhancements
like  'globstar' will help porting build scripts from other Node-based
build systems like Gulp and Grunt.

Also, I think developer's will generally expect Bash semanatics,
so this follows the "principle of least surprise" in that regard.

We may want to consider enabling other bash extensions by default as
well, including "extglob" for extending glob Regex support, or
"nullglob", which seems like to work like Gulp's "allowEmpty" option for
gulp.src.

Note that `globstar` was added in Bash 4, but that's been out for 8+
years or so.

I tested the performance of launching 'bash' vs 'sh' to see if there
would be performance difference there. In my test, bash was an
insigificant millisecond or two slower to launch.

 time sh -c "echo 42"
 time bash -c "echo 42"

Further notes:

 - As part of this change, it's worth reconsidering if the default of
   passing through `process.env` completely should be reconsidered, or if
   specific variables should be whitelisted. We don't want developer's
   local `bash` customizations to lead to incosistent results. Locking
   down a consistent run environment is best.

 - Thinking along the lines above, `BASHOPTS` is explicitly not
   inherited from the parent shell process. `SHELLOPTS` is another
   variable that perhaps should not be passed through as well.

An alternative way get Node-style globing would be install the
`glob-cli2` package, which would provide a `glob` binary.
The binary would then use Node to handle the globbing, passing a static
list of files back to bash.