### PR TITLE
Sort list of commands. Fixes #74.

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,7 @@ const { run } = require('runjs')
 {
     cwd: ..., // current working directory (String)
     async: ... // run command asynchronously (true/false), false by default
+    input: ... // for sync calls, explicitly pass STDIN.
     stdio: ... // 'inherit' (default), 'pipe' or 'ignore'
     env: ... // environment key-value pairs (Object)
     timeout: ...
@@ -516,6 +517,10 @@ run('http-server .', {async: true, stdio: 'pipe'}).then((output) => {
 }).catch((error) => {
   throw error
 })
+
+// Provide a list of files to rsync via STDIN
+const files = glob('**/*.html').join(' ')
+const output = run('rsync --files-from - ...', {input: files, stdio: 'pipe'})
 ```
 
 For `stdio: 'pipe'` outputs are returned but not forwarded to the parent process thus 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "yarn lint && flow check && yarn build && yarn sandbox:dev && jest ./test --coverage",
     "test:unit": "jest ./test/unit/",
     "test:e2e": "jest ./test/e2e/",
-    "test:prod": "yarn sandbox:setup:prod && jest ./test/e2e/",
+    "test:prod": "yarn sandbox:prod && jest ./test/e2e/",
     "sandbox:clean": "rm -rf ./test/e2e/sandbox/node_modules && mkdir -p ./test/e2e/sandbox/node_modules/.bin",
     "sandbox:dev": "yarn sandbox:clean && ln -s ../../../../ ./test/e2e/sandbox/node_modules/runjs",
     "sandbox:prod": "yarn sandbox:clean && (cd ./test/e2e/sandbox && yarn add runjs)",

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ const loggerAlias: Logger = logger
 type Options = {
   cwd?: string,
   async?: boolean,
+  input?: string,
   stdio?: string | Array<any>,
   env?: Object,
   timeout?: number
@@ -18,9 +19,11 @@ function runSync(command: string, options: Options): ?string {
     const nextOptions = {
       cwd: options.cwd,
       env: options.env,
+      input: options.input,
       stdio: options.stdio,
       timeout: options.timeout
     }
+
     const buffer: string | Buffer = execSync(command, nextOptions)
     if (buffer) {
       return buffer.toString()
@@ -104,6 +107,9 @@ export function run(
   }
 
   // Handle sync call by default
+  if (typeof options.input !== 'undefined') {
+    nextOptions.input = options.input
+  }
   return runSync(command, nextOptions)
 }
 

--- a/src/script.js
+++ b/src/script.js
@@ -69,34 +69,36 @@ export function describe(obj: Object, logger: Logger, namespace: ?string) {
     logger.log(chalk.yellow('Available tasks:'))
   }
 
-  Object.keys(obj).forEach(key => {
-    const value = obj[key]
-    const nextNamespace = namespace ? `${namespace}:${key}` : key
-    const help = value.help
+  Object.keys(obj)
+    .sort()
+    .forEach(key => {
+      const value = obj[key]
+      const nextNamespace = namespace ? `${namespace}:${key}` : key
+      const help = value.help
 
-    if (typeof value === 'function') {
-      // Add task name
-      const funcParams = help && help.params
-      let logArgs = [chalk.bold(nextNamespace)]
+      if (typeof value === 'function') {
+        // Add task name
+        const funcParams = help && help.params
+        let logArgs = [chalk.bold(nextNamespace)]
 
-      // Add task params
-      if (Array.isArray(funcParams) && funcParams.length) {
-        logArgs[0] += ` [${funcParams.join(' ')}]`
+        // Add task params
+        if (Array.isArray(funcParams) && funcParams.length) {
+          logArgs[0] += ` [${funcParams.join(' ')}]`
+        }
+
+        // Add description
+        if (help && (help.description || typeof help === 'string')) {
+          const description = help.description || help
+          logArgs[0] = padEnd(logArgs[0], 40) // format
+          logArgs.push('-', description.split('\n')[0])
+        }
+
+        // Log
+        logger.log(...logArgs)
+      } else if (typeof value === 'object') {
+        describe(value, logger, nextNamespace)
       }
-
-      // Add description
-      if (help && (help.description || typeof help === 'string')) {
-        const description = help.description || help
-        logArgs[0] = padEnd(logArgs[0], 40) // format
-        logArgs.push('-', description.split('\n')[0])
-      }
-
-      // Log
-      logger.log(...logArgs)
-    } else if (typeof value === 'object') {
-      describe(value, logger, nextNamespace)
-    }
-  })
+    })
 
   if (!namespace) {
     logger.log(

--- a/test/e2e/e2e.spec.js
+++ b/test/e2e/e2e.spec.js
@@ -45,6 +45,12 @@ describe('runjs', () => {
     expect(sh('../../../bin/run.js echo --help')).toContain('Simple echo task')
   })
 
+  it('sorts list of tasks', () => {
+    expect(sh('../../../bin/run.js')).toEqual(
+      expect.stringMatching(/asyncawait[^]+color[^]+echo[^]+error[^]+nested/)
+    )
+  })
+
   it('displays error from executed command', () => {
     expect(() => sh('../../../bin/run.js error')).toThrow(
       'Command failed: ../../../bin/run.js error'

--- a/test/unit/index.spec.js
+++ b/test/unit/index.spec.js
@@ -34,6 +34,14 @@ describe('api', () => {
     })
 
     describe('sync version', () => {
+      describe('with input=test', () => {
+        it('should pass input to run', () => {
+          const output = api.run('cat', { input: 'test' }, logger)
+          expect(execSync.mock.calls[0][0]).toEqual('cat')
+          expect(execSync.mock.calls[0][1]).toHaveProperty('input', 'test')
+        })
+      })
+
       describe('with stdio=pipe', () => {
         it('should execute basic shell commands', () => {
           const output = api.run('echo "echo test"', { stdio: 'pipe' }, logger)


### PR DESCRIPTION
Manually tested before/after.

Sorry about all the whitespace changes included-- the "prettier" integration insisted I make the changes.

All I did was add a well-placed `.sort()` call. The rest is formatting. 