### PR TITLE
Add support for explicitly passing STDIN to sync calls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,7 @@ const { run } = require('runjs')
 {
     cwd: ..., // current working directory (String)
     async: ... // run command asynchronously (true/false), false by default
+    input: ... // for sync calls, explicitly pass STDIN.
     stdio: ... // 'inherit' (default), 'pipe' or 'ignore'
     env: ... // environment key-value pairs (Object)
     timeout: ...
@@ -516,6 +517,10 @@ run('http-server .', {async: true, stdio: 'pipe'}).then((output) => {
 }).catch((error) => {
   throw error
 })
+
+// Provide a list of files to rsync via STDIN
+const files = glob('**/*.html').join(' ')
+const output = run('rsync --files-from - ...', {input: files, stdio: 'pipe'})
 ```
 
 For `stdio: 'pipe'` outputs are returned but not forwarded to the parent process thus 

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ const loggerAlias: Logger = logger
 type Options = {
   cwd?: string,
   async?: boolean,
+  input?: string,
   stdio?: string | Array<any>,
   env?: Object,
   timeout?: number
@@ -18,9 +19,11 @@ function runSync(command: string, options: Options): ?string {
     const nextOptions = {
       cwd: options.cwd,
       env: options.env,
+      input: options.input,
       stdio: options.stdio,
       timeout: options.timeout
     }
+
     const buffer: string | Buffer = execSync(command, nextOptions)
     if (buffer) {
       return buffer.toString()
@@ -104,6 +107,9 @@ export function run(
   }
 
   // Handle sync call by default
+  if (typeof options.input !== 'undefined') {
+    nextOptions.input = options.input
+  }
   return runSync(command, nextOptions)
 }
 

--- a/test/unit/index.spec.js
+++ b/test/unit/index.spec.js
@@ -34,6 +34,14 @@ describe('api', () => {
     })
 
     describe('sync version', () => {
+      describe('with input=test', () => {
+        it('should pass input to run', () => {
+          const output = api.run('cat', { input: 'test' }, logger)
+          expect(execSync.mock.calls[0][0]).toEqual('cat')
+          expect(execSync.mock.calls[0][1]).toHaveProperty('input', 'test')
+        })
+      })
+
       describe('with stdio=pipe', () => {
         it('should execute basic shell commands', () => {
           const output = api.run('echo "echo test"', { stdio: 'pipe' }, logger)


### PR DESCRIPTION
Consider the case where you want to rsync all HTML files spread throughout a directory there.
There are over a 1,000 files.

Also, this needs to run Windows cmd.exe, which doesn't support the "globstar" syntax.

The file globbing can be Node.js and a long fist of files can be passed to `rsync` via STDIN.

This keeps the command to run and short, while also avoiding error on Windows about the command line beign too long.

This is implemented using the "input" option already supported by `execSync()`.

The `spawn` command doesn't support the `input` option, so no attempt  was made
to support this for `async` run calls.
